### PR TITLE
OXID 6 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Tip: Use the [OXID module connector](https://github.com/OXIDprojects/OXID-Module
 
 Changelog
 
+	2020-03-19	1.2.0 make the module compatible with OXID 6
 	2015-11-29	1.1.0	remove changed_full, add blocks, add auto-installer
 	2013-06-15	1.0.1	add changed_full
 	2013-05-27	1.0.0	module release

--- a/copy_this/modules/proudsourcing/psCmsSnippets/application/controllers/pscmssnippets_content.php
+++ b/copy_this/modules/proudsourcing/psCmsSnippets/application/controllers/pscmssnippets_content.php
@@ -25,7 +25,7 @@ class psCmsSnippets_content extends psCmsSnippets_content_parent
         $oContent = $this->getContent();
         if($oContent->oxcontents__pscmssnippets_disable->value)
         {
-            oxUtils::getInstance()->redirect( $this->getConfig()->getShopUrl(), false, 410 );
+            oxRegistry::getUtils()->redirect( $this->getConfig()->getShopUrl(), false, 410 );
         }
         return $mReturn;
     }

--- a/copy_this/modules/proudsourcing/psCmsSnippets/core/pscmssnippets_setup.php
+++ b/copy_this/modules/proudsourcing/psCmsSnippets/core/pscmssnippets_setup.php
@@ -19,7 +19,7 @@ class pscmssnippets_setup extends oxSuperCfg
         $db = oxDb::getDb();
         try {
             if(!self::dbColumnExist('oxcontents', 'PSCMSSNIPPETS_DISABLE')) {
-                $db->Execute("ALTER IGNORE TABLE `oxcontents` ADD `PSCMSSNIPPETS_DISABLE` TINYINT(1) NOT NULL DEFAULT '0'");
+                $db->Execute("ALTER TABLE `oxcontents` ADD `PSCMSSNIPPETS_DISABLE` TINYINT(1) NOT NULL DEFAULT '0'");
             }
 
             // clear tmp dir

--- a/copy_this/modules/proudsourcing/psCmsSnippets/metadata.php
+++ b/copy_this/modules/proudsourcing/psCmsSnippets/metadata.php
@@ -26,7 +26,7 @@ $aModule = array(
         'en' => 'Setting for CMS pages, which may not be accessible via browser.',
     ),
     'thumbnail'    => 'logo_pc-os.jpg',
-    'version'      => '1.1.0',
+    'version'      => '1.2.0',
     'author'       => 'Proud Sourcing GmbH',
     'url'          => 'http://www.proudcommerce.com',
     'email'        => 'support@proudcommerce.com',


### PR DESCRIPTION
This PR fixes 2 problems that occurred when running with OXID 6:
1. Apparently, `ALTER IGNORE` is not supported by newer MySQL versions (?). It's not needed here anyway, since there's a check if the respective column exists in the line above.
2. `oxUtils::getInstance()` has been [deprecated](https://docs.oxid-esales.com/sourcecodedocumentation/4.8.11/deprecated.html#_deprecated000167) for a long time (since 2012, to be precise). I replaced it by `oxRegistry::getUtils()`